### PR TITLE
Restructure code into packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ $ go get github.com/benbalter/zoom-go/cmd/zoom
 ```
 
 This will install a `zoom` executable file into `$GOPATH/bin/zoom`.
+
+## Usage
+
+Ensure `$GOPATH/bin` is in your `$PATH`, and run `zoom`! That's all.
+
+## Authorization
+
+The first time you run `zoom`, you will see instructions for how to create a Google app in the Developer Console, authorize it to access your calendar, download credentials, then import the credentials into `zoom`. After you import, you should be walked through the process of authorizing in the browser. Paste the authorization code back into your terminal, and vòila, `zoom` will be all configured for your next run.

--- a/client.go
+++ b/client.go
@@ -1,0 +1,32 @@
+package zoom
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/benbalter/zoom-go/config"
+	calendar "google.golang.org/api/calendar/v3"
+)
+
+// NewGoogleClient creates a new client using the token from the given provider.
+func NewGoogleClient(provider config.Provider) (*http.Client, error) {
+	conf, err := provider.GetGoogleClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := provider.GetGoogleToken()
+	if err != nil {
+		return nil, err
+	}
+	return conf.Client(context.Background(), token), nil
+}
+
+// NewGoogleCalendarService creates a new Google Calendar service with the credentials in the provider.
+func NewGoogleCalendarService(provider config.Provider) (*calendar.Service, error) {
+	client, err := NewGoogleClient(provider)
+	if err != nil {
+		return nil, err
+	}
+	return calendar.New(client)
+}

--- a/client.go
+++ b/client.go
@@ -5,17 +5,19 @@ import (
 	"net/http"
 
 	"github.com/benbalter/zoom-go/config"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
 	calendar "google.golang.org/api/calendar/v3"
 )
 
 // NewGoogleClient creates a new client using the token from the given provider.
 func NewGoogleClient(provider config.Provider) (*http.Client, error) {
-	conf, err := provider.GetGoogleClientConfig()
+	conf, err := provider.GoogleClientConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := provider.GetGoogleToken()
+	token, err := provider.GoogleToken()
 	if err != nil {
 		return nil, err
 	}
@@ -29,4 +31,29 @@ func NewGoogleCalendarService(provider config.Provider) (*calendar.Service, erro
 		return nil, err
 	}
 	return calendar.New(client)
+}
+
+// GoogleCalendarAuthorizationURL returns the authorization URL for the service configured in the provider.
+func GoogleCalendarAuthorizationURL(provider config.Provider) (string, error) {
+	conf, err := provider.GoogleClientConfig()
+	if err != nil {
+		return "", err
+	}
+
+	return conf.AuthCodeURL("state-token", oauth2.AccessTypeOffline), nil
+}
+
+// HandleGoogleCalendarAuthorization takes an auth code and generates the necessary token and stores it on the provider.
+func HandleGoogleCalendarAuthorization(provider config.Provider, authCode string) error {
+	conf, err := provider.GoogleClientConfig()
+	if err != nil {
+		return err
+	}
+
+	tok, err := conf.Exchange(oauth2.NoContext, authCode)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return provider.StoreGoogleToken(tok)
 }

--- a/cmd/zoom/main.go
+++ b/cmd/zoom/main.go
@@ -108,22 +108,27 @@ func main() {
 		return
 	}
 
-	fmt.Printf("Your next meeting is %q.\n", meeting.Summary)
+	fmt.Printf("Your next meeting is %q, organized by %s.\n", meeting.Summary, meeting.Organizer.DisplayName)
+
+	startTime, err := zoom.MeetingStartTime(meeting)
+	if startTime.Sub(time.Now()) < 0 {
+		fmt.Printf("It started %s.\n", zoom.HumanizedStartTime(meeting))
+	} else {
+		fmt.Printf("It starts %s.\n", zoom.HumanizedStartTime(meeting))
+	}
+
+	fmt.Printf("Calendar event URL: %s\n\n", meeting.HtmlLink)
 
 	url, ok := zoom.MeetingURLFromEvent(meeting)
 	if !ok {
-		fmt.Println("Your next meeting is not a Zoom meeting.")
+		fmt.Println("No Zoom URL found in the meeting.")
 		os.Exit(1)
 	}
-
-	fmt.Printf("It starts %s", zoom.HumanizedStartTime(meeting))
 
 	if zoom.IsMeetingSoon(meeting) {
 		fmt.Printf("Opening %s...\n", url)
 		open.Run(url.String())
 	} else {
-		fmt.Printf("Here's the URL %s\n", url)
+		fmt.Printf("Zoom URL: %s\n", url)
 	}
-
-	fmt.Printf("Oh, and here's the URL in case you need it: %s\n", meeting.HtmlLink)
 }

--- a/cmd/zoom/main.go
+++ b/cmd/zoom/main.go
@@ -1,20 +1,94 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/skratchdot/open-golang/open"
 
 	zoom "github.com/benbalter/zoom-go"
 	"github.com/benbalter/zoom-go/config"
 )
 
+func printSetupInstructions() {
+	fmt.Print(`In order to use Zoom Launcher, you need to create an OAuth app and authorize it to access your calendar. 
+You can do it in four, not-so-easy steps:
+
+1. Create a new project
+	1. Go to https://console.developers.google.com
+	2. Switch to your work account if need be (top right)
+	3. Create a new project dropdown, top left next to your domain
+2. Grant the project Calendar API access
+	1. Click "Enable API"
+	2. Type "Calendar" in the search box
+	3. Click "Calendar API"
+	4. Click "Enable"
+3. Grab your credentials
+	1. Click "Credentials" on the left side
+	2. Create a new OAuth credential with type "other"
+	3. Download the credential to ~/.config/google/client_secrets.json (icon, right side)
+4. Run 'zoom -import=Downloads/client_secrets.json' and follow the instructions to authorize the app.
+`)
+}
+
+func importGoogleClientConfig(provider config.Provider, filename string) error {
+	conf, err := config.ReadGoogleClientConfigFromFile(filename)
+	if err != nil {
+		return err
+	}
+
+	return provider.StoreGoogleClientConfig(conf)
+}
+
+func authorizeAccount(provider config.Provider) error {
+	authURL, err := zoom.GoogleCalendarAuthorizationURL(provider)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Your browser is about to open. When it does, please authorize the application when prompted and paste the token it gives you below.")
+	time.Sleep(5 * time.Second)
+	open.Run(authURL)
+
+	fmt.Print("Authorization token: ")
+	var authCode string
+	if _, err := fmt.Scan(&authCode); err != nil {
+		return errors.WithStack(err)
+	}
+	return zoom.HandleGoogleCalendarAuthorization(provider, authCode)
+}
+
 func main() {
 	provider, err := config.NewFileProvider()
 	if err != nil {
 		fmt.Printf("unable to create file configuration provider: %+v\n", err)
 		os.Exit(1)
+	}
+
+	importCredential := flag.String("import", "", "Full path to your downloaded Google OAuth2 client_secret JSON file")
+	flag.Parse()
+
+	if importCredential != nil && *importCredential != "" {
+		fmt.Printf("Importing credentials from %q...\n", *importCredential)
+		if err := importGoogleClientConfig(provider, *importCredential); err != nil {
+			fmt.Printf("error importing credentials: %+v\n", err)
+		}
+	}
+
+	if !provider.GoogleClientConfigExists() {
+		printSetupInstructions()
+		os.Exit(1)
+	}
+
+	if !provider.GoogleTokenExists() {
+		if err := authorizeAccount(provider); err != nil {
+			fmt.Printf("error authorizing: %+v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Stored credentials.")
 	}
 
 	calendar, err := zoom.NewGoogleCalendarService(provider)

--- a/cmd/zoom/main.go
+++ b/cmd/zoom/main.go
@@ -1,199 +1,54 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"net/url"
 	"os"
-	"os/user"
-	"path"
-	"regexp"
-	"strconv"
-	"time"
 
-	humanize "github.com/dustin/go-humanize"
-	open "github.com/skratchdot/open-golang/open"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
-	calendar "google.golang.org/api/calendar/v3"
+	"github.com/skratchdot/open-golang/open"
+
+	zoom "github.com/benbalter/zoom-go"
+	"github.com/benbalter/zoom-go/config"
 )
 
-func inConfigDir(file string) string {
-	usr, err := user.Current()
-
-	if err != nil {
-		log.Fatalf("Can't find home directory: %v", err)
-	}
-
-	return path.Join(usr.HomeDir, ".config", "google", file)
-}
-
-// Retrieve a token, saves the token, then returns the generated client.
-func getClient(config *oauth2.Config) *http.Client {
-
-	tokFile := inConfigDir("token.json")
-	tok, err := tokenFromFile(tokFile)
-	if err != nil {
-		tok = getTokenFromWeb(config)
-		saveToken(tokFile, tok)
-	}
-	return config.Client(context.Background(), tok)
-}
-
-// Request a token from the web, then returns the retrieved token.
-func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
-	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
-
-	fmt.Println("Your browser is about to open. When it does, please authorize the application when prompted and paste the token it gives you below")
-	fmt.Println("Authorization token: ")
-	time.Sleep(5 * time.Second)
-	open.Run(authURL)
-
-	var authCode string
-	if _, err := fmt.Scan(&authCode); err != nil {
-		log.Fatalf("Unable to read authorization code: %v", err)
-	}
-
-	tok, err := config.Exchange(oauth2.NoContext, authCode)
-	if err != nil {
-		log.Fatalf("Unable to retrieve token from web: %v", err)
-	}
-	return tok
-}
-
-// Retrieves a token from a local file.
-func tokenFromFile(file string) (*oauth2.Token, error) {
-	f, err := os.Open(file)
-	defer f.Close()
-	if err != nil {
-		return nil, err
-	}
-	tok := &oauth2.Token{}
-	err = json.NewDecoder(f).Decode(tok)
-	return tok, err
-}
-
-// Saves a token to a file path.
-func saveToken(path string, token *oauth2.Token) {
-	fmt.Printf("Saving credential file to: %s\n", path)
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	defer f.Close()
-	if err != nil {
-		log.Fatalf("Unable to cache oauth token: %v", err)
-	}
-	json.NewEncoder(f).Encode(token)
-}
-
-func zoomURL(meeting *calendar.Event) (*url.URL, error) {
-	fullURL, meetingID, matched := meetingURLParts(meeting)
-
-	if !matched {
-		return url.Parse("")
-	} else if _, err := strconv.Atoi(meetingID); err == nil {
-		return url.Parse("zoommtg://zoom.us/join?confno=" + meetingID)
-	} else {
-		return url.Parse(fullURL)
-	}
-}
-
-func inPast(meeting *calendar.Event) bool {
-	return meeting.Start.DateTime < time.Now().Format(time.RFC3339)
-}
-
-func startTime(meeting *calendar.Event) (time.Time, error) {
-	return time.Parse(time.RFC3339, meeting.Start.DateTime)
-}
-
-func humanizedStartTime(meeting *calendar.Event) string {
-	time, _ := startTime(meeting)
-	return humanize.Time(time)
-}
-
-func moreThanFiveMinutesFromNow(meeting *calendar.Event) bool {
-	start, _ := startTime(meeting)
-	return time.Until(start).Minutes() > 5
-}
-
-func service() *calendar.Service {
-	file := inConfigDir("client_secrets.json")
-	b, err := ioutil.ReadFile(file)
-	if err != nil {
-		log.Fatalf("Unable to read client secret file: %v", err)
-	}
-
-	// If modifying these scopes, delete your previously saved client_secret.json.
-	config, err := google.ConfigFromJSON(b, calendar.CalendarReadonlyScope)
-	if err != nil {
-		log.Fatalf("Unable to parse client secret file to config: %v", err)
-	}
-
-	srv, err := calendar.New(getClient(config))
-	if err != nil {
-		log.Fatalf("Unable to retrieve Calendar client: %v", err)
-	}
-
-	return srv
-}
-
-func events() *calendar.Events {
-	t := time.Now().Format(time.RFC3339)
-	events, err := service().Events.List("primary").ShowDeleted(false).
-		SingleEvents(true).TimeMin(t).MaxResults(1).OrderBy("startTime").Do()
-
-	if err != nil {
-		log.Fatalf("Unable to retrieve next meeting: %v", err)
-	}
-
-	return events
-}
-
-func meetingURLParts(meeting *calendar.Event) (string, string, bool) {
-	r, _ := regexp.Compile(`https://.*?\.zoom\.us/(?:j/(\d+)|my/(\S+))`)
-	matches := r.FindAllStringSubmatch(meeting.Location+" "+meeting.Description, -1)
-
-	if len(matches) > 0 {
-		return matches[0][0], matches[0][1], true
-	}
-
-	return "", "", false
-}
-
 func main() {
-	events := events()
+	provider, err := config.NewFileProvider()
+	if err != nil {
+		fmt.Printf("unable to create file configuration provider: %+v\n", err)
+		os.Exit(1)
+	}
 
-	if len(events.Items) == 0 {
+	calendar, err := zoom.NewGoogleCalendarService(provider)
+	if err != nil {
+		fmt.Printf("error creating google calendar client: %+v\n", err)
+		os.Exit(1)
+	}
+
+	meeting, err := zoom.NextEvent(calendar)
+	if err != nil {
+		fmt.Printf("error fetching next meeting: %+v\n", err)
+		os.Exit(1)
+	}
+
+	if meeting == nil {
 		fmt.Println("No upcoming events found.")
 		return
 	}
 
-	meeting := events.Items[0]
-	url, err := zoomURL(meeting)
+	fmt.Printf("Your next meeting is %q.\n", meeting.Summary)
 
-	if err != nil || url.String() == "" {
-		fmt.Println("Your next meeting isn't a Zoom meeting")
-		return
+	url, ok := zoom.MeetingURLFromEvent(meeting)
+	if !ok {
+		fmt.Println("Your next meeting is not a Zoom meeting.")
+		os.Exit(1)
 	}
 
-	fmt.Printf("Your next Zoom meeting is %s\n", meeting.Summary)
+	fmt.Printf("It starts %s", zoom.HumanizedStartTime(meeting))
 
-	isWas := ""
-	if inPast(meeting) {
-		isWas = "was"
-	} else {
-		isWas = "is"
-	}
-
-	fmt.Printf("It %s scheduled to start %s\n", isWas, humanizedStartTime(meeting))
-
-	if moreThanFiveMinutesFromNow(meeting) {
-		fmt.Printf("Here's the URL %s\n", url)
-	} else {
+	if zoom.IsMeetingSoon(meeting) {
 		fmt.Printf("Opening %s...\n", url)
 		open.Run(url.String())
+	} else {
+		fmt.Printf("Here's the URL %s\n", url)
 	}
 
 	fmt.Printf("Oh, and here's the URL in case you need it: %s\n", meeting.HtmlLink)

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,76 @@
+// package config
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	calendar "google.golang.org/api/calendar/v3"
+)
+
+// Provider is a token provider.
+type Provider interface {
+	// GetGoogleClientConfig returns the Google client config.
+	GetGoogleClientConfig() (*oauth2.Config, error)
+
+	// GetGoogleToken returns the Google token.
+	GetGoogleToken() (*oauth2.Token, error)
+
+	// SaveGoogleToken writes the Google token.
+	SaveGoogleToken(token *oauth2.Token) error
+}
+
+// FileProvider is a Provider which uses files to store data.
+type FileProvider struct {
+	directory string
+}
+
+// NewFileProvider returns a new FileProvider with the default filepath.
+func NewFileProvider() (FileProvider, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return FileProvider{}, err
+	}
+
+	return FileProvider{
+		directory: filepath.Join(usr.HomeDir, ".config", "google"),
+	}, nil
+}
+
+// GetGoogleClientConfig returns the Google client configuration from the configuration file.
+func (f FileProvider) GetGoogleClientConfig() (*oauth2.Config, error) {
+	b, err := ioutil.ReadFile(filepath.Join(f.directory, "client_secrets.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	// If modifying these scopes, delete your previously saved client_secret.json.
+	return google.ConfigFromJSON(b, calendar.CalendarReadonlyScope)
+}
+
+// GetGoogleToken fetches the Google token from the configuration file.
+func (f FileProvider) GetGoogleToken() (*oauth2.Token, error) {
+	token := &oauth2.Token{}
+
+	fd, err := os.Open(filepath.Join(f.directory, "token.json"))
+	if err != nil {
+		return token, err
+	}
+
+	return token, json.NewDecoder(fd).Decode(token)
+}
+
+// SaveGoogleToken writes the Google token to the configuration file.
+func (f FileProvider) SaveGoogleToken(token *oauth2.Token) error {
+	fd, err := os.Create(filepath.Join(f.directory, "token.json"))
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(fd).Encode(token)
+}

--- a/config/file.go
+++ b/config/file.go
@@ -45,9 +45,19 @@ func (f *FileProvider) GoogleClientConfig() (*oauth2.Config, error) {
 		return f.cachedGoogleClientConfig, nil
 	}
 
-	conf := &oauth2.Config{}
+	path := filepath.Join(f.directory, googleClientConfigFilename)
 
-	fd, err := os.Open(filepath.Join(f.directory, googleClientConfigFilename))
+	conf, err := ReadGoogleClientConfigFromFile(path)
+	if err != nil && err.Error() != "oauth2/google: no credentials found" {
+		return conf, err
+	}
+	if err == nil && conf != nil {
+		return conf, f.StoreGoogleClientConfig(conf)
+	}
+
+	conf = &oauth2.Config{}
+
+	fd, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, ErrNoGoogleClientConfig

--- a/config/file.go
+++ b/config/file.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+)
+
+const googleClientConfigFilename = "client_secrets.json"
+const googleTokenFilename = "token.json"
+
+// FileProvider is a Provider which uses files to store data.
+type FileProvider struct {
+	directory string
+
+	cachedGoogleClientConfig *oauth2.Config
+	cachedGoogleToken        *oauth2.Token
+}
+
+// NewFileProvider returns a new FileProvider with the default filepath.
+func NewFileProvider() (*FileProvider, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &FileProvider{
+		directory: filepath.Join(usr.HomeDir, ".config", "google"),
+	}, nil
+}
+
+// GoogleClientConfigExists returns true if the config is readable and valid, false otherwise.
+func (f *FileProvider) GoogleClientConfigExists() bool {
+	conf, err := f.GoogleClientConfig()
+	return conf != nil && err == nil
+}
+
+// GoogleClientConfig returns the Google client configuration from the configuration file.
+func (f *FileProvider) GoogleClientConfig() (*oauth2.Config, error) {
+	if f.cachedGoogleClientConfig != nil {
+		return f.cachedGoogleClientConfig, nil
+	}
+
+	conf := &oauth2.Config{}
+
+	fd, err := os.Open(filepath.Join(f.directory, googleClientConfigFilename))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoGoogleClientConfig
+		}
+		return nil, errors.WithStack(err)
+	}
+
+	f.cachedGoogleClientConfig = conf
+
+	return conf, json.NewDecoder(fd).Decode(conf)
+}
+
+// StoreGoogleClientConfig writes the Google client config to the configuration file.
+func (f *FileProvider) StoreGoogleClientConfig(conf *oauth2.Config) error {
+	f.cachedGoogleClientConfig = conf
+
+	fd, err := os.Create(filepath.Join(f.directory, googleClientConfigFilename))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return json.NewEncoder(fd).Encode(conf)
+}
+
+// GoogleTokenExists returns true if the token is readable and valid, false otherwise.
+func (f *FileProvider) GoogleTokenExists() bool {
+	token, err := f.GoogleToken()
+	return token != nil && err == nil
+}
+
+// GoogleToken fetches the Google token from the configuration file.
+func (f *FileProvider) GoogleToken() (*oauth2.Token, error) {
+	if f.cachedGoogleToken != nil {
+		return f.cachedGoogleToken, nil
+	}
+
+	token := &oauth2.Token{}
+
+	fd, err := os.Open(filepath.Join(f.directory, googleTokenFilename))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoGoogleToken
+		}
+		return nil, errors.WithStack(err)
+	}
+
+	f.cachedGoogleToken = token
+
+	return token, json.NewDecoder(fd).Decode(token)
+}
+
+// StoreGoogleToken writes the Google token to the configuration file.
+func (f *FileProvider) StoreGoogleToken(token *oauth2.Token) error {
+	f.cachedGoogleToken = token
+
+	fd, err := os.Create(filepath.Join(f.directory, googleTokenFilename))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return json.NewEncoder(fd).Encode(token)
+}

--- a/zoom.go
+++ b/zoom.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
 	calendar "google.golang.org/api/calendar/v3"
 )
 
@@ -26,7 +27,7 @@ func NextEvent(service *calendar.Service) (*calendar.Event, error) {
 		OrderBy("startTime").
 		Do()
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	if len(events.Items) == 0 {

--- a/zoom.go
+++ b/zoom.go
@@ -1,0 +1,79 @@
+// Package zoom provides a way to fetch the next Zoom meeting in your Google calendar.
+package zoom
+
+import (
+	"net/url"
+	"regexp"
+	"strconv"
+	"time"
+
+	humanize "github.com/dustin/go-humanize"
+	calendar "google.golang.org/api/calendar/v3"
+)
+
+var zoomURLRegexp = regexp.MustCompile(`https://.*?\.zoom\.us/(?:j/(\d+)|my/(\S+))`)
+
+// NextEvent returns the next calendar event in your primary calendar.
+func NextEvent(service *calendar.Service) (*calendar.Event, error) {
+	t := time.Now().Format(time.RFC3339)
+
+	events, err := service.Events.
+		List("primary").
+		ShowDeleted(false).
+		SingleEvents(true).
+		TimeMin(t).
+		MaxResults(1).
+		OrderBy("startTime").
+		Do()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(events.Items) == 0 {
+		return nil, nil
+	}
+
+	return events.Items[0], nil
+}
+
+// MeetingURLFromEvent returns a URL if the event is a Zoom meeting.
+func MeetingURLFromEvent(event *calendar.Event) (*url.URL, bool) {
+	matches := zoomURLRegexp.FindAllStringSubmatch(event.Location+" "+event.Description, -1)
+	if len(matches) == 0 || len(matches[0]) == 0 {
+		return nil, false
+	}
+
+	// By default, match the whole URL.
+	stringURL := matches[0][0]
+
+	// If we have a meeting ID in the URL, then use zoommtg:// instead of the HTTPS URL.
+	if len(matches[0]) >= 2 {
+		if _, err := strconv.Atoi(matches[0][1]); err == nil {
+			stringURL = "zoommtg://zoom.us/join?confno=" + matches[0][1]
+		}
+	}
+
+	parsedURL, err := url.Parse(stringURL)
+	if err != nil {
+		return nil, false
+	}
+	return parsedURL, true
+}
+
+// IsMeetingSoon returns true if the meeting is less than 5 minutes from now.
+func IsMeetingSoon(event *calendar.Event) bool {
+	startTime, err := time.Parse(time.RFC3339, event.Start.DateTime)
+	if err != nil {
+		return false
+	}
+	return time.Until(startTime).Minutes() < 5
+}
+
+// HumanizedStartTime converts the event's start time to a human-friendly statement.
+func HumanizedStartTime(event *calendar.Event) string {
+	startTime, err := time.Parse(time.RFC3339, event.Start.DateTime)
+	if err != nil {
+		return err.Error()
+	}
+	return humanize.Time(startTime)
+}

--- a/zoom.go
+++ b/zoom.go
@@ -63,7 +63,7 @@ func MeetingURLFromEvent(event *calendar.Event) (*url.URL, bool) {
 
 // IsMeetingSoon returns true if the meeting is less than 5 minutes from now.
 func IsMeetingSoon(event *calendar.Event) bool {
-	startTime, err := time.Parse(time.RFC3339, event.Start.DateTime)
+	startTime, err := MeetingStartTime(event)
 	if err != nil {
 		return false
 	}
@@ -72,9 +72,14 @@ func IsMeetingSoon(event *calendar.Event) bool {
 
 // HumanizedStartTime converts the event's start time to a human-friendly statement.
 func HumanizedStartTime(event *calendar.Event) string {
-	startTime, err := time.Parse(time.RFC3339, event.Start.DateTime)
+	startTime, err := MeetingStartTime(event)
 	if err != nil {
 		return err.Error()
 	}
 	return humanize.Time(startTime)
+}
+
+// MeetingStartTime returns the calendar event's start time.
+func MeetingStartTime(event *calendar.Event) (time.Time, error) {
+	return time.Parse(time.RFC3339, event.Start.DateTime)
 }


### PR DESCRIPTION
Hey @benbalter! This is a big one, so let me explain:

1. I created a `config/` package. This package provides an interface type called `Provider`. It currently has one implementation, `FileProvider`, which reads from `~/.config/google`. In a subsequent PR, I want to add OS X keychain support as a separate provider.
2. I moved any non-interactive logic to `zoom.go` and `client.go` in the base. Things like setting up the calendar service and anything else related to querying Google, parsing zoom links, etc. All the other "domain logic" that didn't make sense in `config/`.
3. `cmd/zoom/main.go` handles 100% of the interaction with the user. All printing to stdout, all reading, all opening of links, etc. It also handles missing `client_secrets.json` and `token.json` files and helps the user set those up.
4. The command now has an `-import` flag. You give it a file path to your client secrets JSON file and it'll import and store it before continuing on. If I have coded it correctly, a brand new user should run `zoom`, follow the instructions to create the Google App, then run `zoom -import=$HOME/Downloads/blah.json`, then follow the instructions to authorize, then it should continue and open their meetings. It's not very _few_ steps, but it works.

That's all! Not so terrible. Next up, I want to write better documentation and tests for these improvements. Documentation may come in this PR, but tests likely won't. 😄 In such a big diff, it'll be easier to review with tests by themselves. Maybe I'll open a PR for each new test file. 🙂 