### PR TITLE
Add goreleaser to build binaries and releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,43 @@
+builds:
+  - main: cmd/zoom/main.go
+    binary: zoom
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+      - freebsd
+      - netbsd
+      - openbsd
+      - dragonfly
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+
+archive:
+  format_overrides:
+    - goos: windows
+      format: zip
+  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  replacements:
+    amd64: 64bit
+    386: 32bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD
+    dragonfly: DragonFlyBSD
+
+# brew:
+#   github:
+#     owner: benbalter
+#     name: homebrew-tap
+#   homepage: https://github.com/benbalter/zoom-go
+#   description: "A command line tool for joining your next Zoom meeting."

--- a/script/release
+++ b/script/release
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+command -v goreleaser > /dev/null || {
+    echo "Please install goreleaser. See https://goreleaser.com/introduction/#installing-goreleaser"
+    echo "If you're using a Mac, we recommend running 'brew install goreleaser/tap/goreleaser'."
+    exit 1
+}
+
+
+# Take next version from args
+version="$1"
+repo="https://github.com/benbalter/zoom-go"
+
+# If "$1" is empty, get version from last git tag
+if [ "$version" = "" ]; then
+    version=$(git tag | tail -n1)
+fi
+
+# Check if the tag is already released
+tag_found=$(curl -fsI --write-out "%{http_code}" "$repo/releases/tag/$version")
+# If the tag is released, exit
+if [ "$tag_found" -eq "200" ]; then
+    echo "tag $version already exists. Please specify a different tag."
+    exit 1
+fi
+
+# Create the tag and run goreleaser
+git tag -a "$version" -m "Release $version" && goreleaser --rm-dist


### PR DESCRIPTION
This pull request adds the goreleaser config to the project. See #5.

The configuration file is taken from https://github.com/kevingimbel/license/blob/master/.goreleaser.yml, so  a release would look similar to https://github.com/kevingimbel/license/releases/tag/v1.0.5

In order to use goreleaser you'll have to install it on your machine and configure a github token (export GITHUB_TOKEN=`YOUR_TOKEN`).

You can then either use it directly or use the wrapper script:

```sh
$ scripts/release  v1.0.0
```

This will create the tag v1.0.0 and release the binary. If the tag `v1.0.0` already exists it will throw an error. If you prefer to do it by hand you can execute the following commands:

```sh
$ git tag -a v1.0.0 -m "First release"
$ goreleaser
```

`goreleaser` will create a "dist" folder with all binaries inside. You probably want to exclude this folder from git. I prefer to run my scripts with the `--rm-dist` option to always remove the `dist` folder if it exists.