### PR TITLE
Allow something that started in the last 5 minutes to be 'soon'

### DIFF
--- a/zoom.go
+++ b/zoom.go
@@ -80,7 +80,7 @@ func IsMeetingSoon(event *calendar.Event) bool {
 		return false
 	}
 	minutesUntilStart := time.Until(startTime).Minutes()
-	return minutesUntilStart > 0 && minutesUntilStart < 5
+	return -5 < minutesUntilStart && minutesUntilStart < 5
 }
 
 // HumanizedStartTime converts the event's start time to a human-friendly statement.

--- a/zoom_test.go
+++ b/zoom_test.go
@@ -181,6 +181,9 @@ func TestIsMeetingSoon(t *testing.T) {
 			DateTime: time.Now().Add(-5 * time.Minute).Format(googleCalendarDateTimeFormat),
 		}}, false},
 		{&calendar.Event{Start: &calendar.EventDateTime{
+			DateTime: time.Now().Add(-2 * time.Minute).Format(googleCalendarDateTimeFormat),
+		}}, true},
+		{&calendar.Event{Start: &calendar.EventDateTime{
 			DateTime: time.Now().Add(5 * time.Minute).Format(googleCalendarDateTimeFormat),
 		}}, true},
 		{&calendar.Event{Start: &calendar.EventDateTime{


### PR DESCRIPTION
Previously, if the meeting started in the past, then it was not automatically opened.

With this patch, if the meeting started within the last 5 minutes, it will automatically open zoom.