### PR TITLE
Fetch Zoom URL from video entrypoints & support multiple events

### DIFF
--- a/zoom.go
+++ b/zoom.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
@@ -18,17 +19,17 @@ const googleCalendarDateTimeFormat = time.RFC3339
 
 var zoomURLRegexp = regexp.MustCompile(`https://.*?\.zoom\.us/(?:j/(\d+)|my/(\S+))`)
 
-// NextEvent returns the next calendar event in your primary calendar.
-// It will list at most 10 events, and select the first one with a Zoom URL if one exists.
-func NextEvent(service *calendar.Service) (*calendar.Event, error) {
-	t := time.Now().Format(time.RFC3339)
+// NextEvents returns the next N calendar events in your primary calendar.
+// It only returns events which contain Zoom video chats.
+func NextEvents(service *calendar.Service, count int) ([]*calendar.Event, error) {
+	t := time.Now().Add(-5 * time.Minute).Format(time.RFC3339)
 
 	events, err := service.Events.
 		List("primary").
 		ShowDeleted(false).
 		SingleEvents(true).
 		TimeMin(t).
-		MaxResults(10).
+		MaxResults(int64(count * 10)).
 		OrderBy("startTime").
 		Do()
 	if err != nil {
@@ -39,14 +40,37 @@ func NextEvent(service *calendar.Service) (*calendar.Event, error) {
 		return nil, nil
 	}
 
+	zoomEvents := []*calendar.Event{}
 	for _, event := range events.Items {
-		if _, ok := MeetingURLFromEvent(event); ok {
-			return event, nil
+		if _, ok := MeetingURLFromEvent(event); !ok {
+			continue
+		}
+
+		zoomEvents = append(zoomEvents, event)
+
+		if len(zoomEvents) == count {
+			break
 		}
 	}
 
-	// We couldn't find an event with a Zoom URL, so just return the first event.
-	return events.Items[0], nil
+	if len(zoomEvents) == 0 {
+		return nil, errors.Errorf("no zoom events upcoming")
+	}
+
+	return zoomEvents, nil
+}
+
+// NextEvent returns the next calendar event in your primary calendar.
+// It will list at most 5 events, and select the first one with a Zoom URL if one exists.
+func NextEvent(service *calendar.Service) (*calendar.Event, error) {
+	events, err := NextEvents(service, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, nil
+	}
+	return events[0], nil
 }
 
 // MeetingURLFromEvent returns a URL if the event is a Zoom meeting.

--- a/zoom_test.go
+++ b/zoom_test.go
@@ -38,7 +38,7 @@ var testEventResponse = `{
 			"kind": "calendar#event",
 			"htmlLink": "lalala",
 			"created": "2018-10-09T17:00:00-07:00",
-			"summary": "I am a video call",
+			"summary": "URI in the location",
 			"description": "I am a description for the video call",
 			"location": "https://jithub.zoom.us/j/12345",
 			"creator": {
@@ -58,7 +58,7 @@ var testEventResponse = `{
 			"kind": "calendar#event",
 			"htmlLink": "lalala",
 			"created": "2018-10-09T17:00:00-07:00",
-			"summary": "I am a video call too",
+			"summary": "URI in the description",
 			"description": "I am a description for the video call\nhttps://jithub.zoom.us/j/12345",
 			"location": "",
 			"creator": {
@@ -78,9 +78,9 @@ var testEventResponse = `{
 			"kind": "calendar#event",
 			"htmlLink": "lalala",
 			"created": "2018-10-09T17:00:00-07:00",
-			"summary": "I am a video call tooooo",
+			"summary": "URI in the conference data entry points",
 			"description": "I am a description for the video call",
-			"location": "https://jithub.zoom.us/j/12345",
+			"location": "I am a location",
 			"creator": {
 				"email": "parkr@jithub.com",
 				"displayName": "Parker Moore"
@@ -92,6 +92,12 @@ var testEventResponse = `{
 			"start": {
 				"dateTime": "2018-10-10T17:30:00-07:00",
 				"timeZone": "America/New_York"
+			},
+			"conferenceData": {
+				"entryPoints": [
+					{"entryPointType": "video", "uri": "https://jithub.zoom.us/j/12345"},
+					{"entryPointType": "phone", "uri": "+12345"}
+				]
 			}
 		}
 	]
@@ -126,9 +132,9 @@ func TestNextEvents(t *testing.T) {
 	require.Len(t, events, 3)
 	assert.Equal(t, 1, actualRequests)
 
-	assert.Equal(t, "I am a video call", events[0].Summary)
-	assert.Equal(t, "I am a video call too", events[1].Summary)
-	assert.Equal(t, "I am a video call tooooo", events[2].Summary)
+	assert.Equal(t, "URI in the location", events[0].Summary)
+	assert.Equal(t, "URI in the description", events[1].Summary)
+	assert.Equal(t, "URI in the conference data entry points", events[2].Summary)
 }
 
 func TestNextEvent(t *testing.T) {
@@ -178,7 +184,7 @@ func TestNextEvent(t *testing.T) {
 			DateTime: "2018-10-10T17:30:00-07:00",
 			TimeZone: "America/New_York",
 		},
-		Summary: "I am a video call",
+		Summary: "URI in the location",
 	}, event)
 }
 


### PR DESCRIPTION
This is commiting the cardinal sin of including two features in one PR.
However, they are split out by commit!

In the first commit, I am allowing a user to pass `-count=N` and print `N`
calendar events. It still opens the soonest one if appropriate. This also
changed the MinTime to be 5 minutes behind now, as a side note.

In the second commit, I am adding support for video entrypoints. It's a neat
way of connecting your calendar to a video service and we're using it a
bunch since it auto-provisions a new room for you. These are in special
fields so require special code.

<img width="323" alt="Screen Shot 2019-06-19 at 9 39 25 PM" src="https://user-images.githubusercontent.com/237985/59818939-bfce3980-92da-11e9-895f-1e5ebdf953dd.png">

<img width="617" alt="Screen Shot 2019-06-19 at 9 41 54 PM" src="https://user-images.githubusercontent.com/237985/59819005-150a4b00-92db-11e9-8478-a7c7989a18f4.png">
