### PR TITLE
Choose event with closest start time

### DIFF
--- a/zoom_test.go
+++ b/zoom_test.go
@@ -211,6 +211,22 @@ func TestNextEvent_NoUpcomingEvents(t *testing.T) {
 	assert.Nil(t, event)
 }
 
+func TestNextEventByStartTime(t *testing.T) {
+	assert.Nil(t, NextEventByStartTime([]*calendar.Event{}))
+
+	events := []*calendar.Event{
+		// Starts 30 minutes ago.
+		{Id: "30 mins ago", Start: &calendar.EventDateTime{DateTime: time.Now().Add(-30 * time.Minute).Format(time.RFC3339)}},
+		// Starts 5 minutes from now.
+		{Id: "5 mins from now", Start: &calendar.EventDateTime{DateTime: time.Now().Add(5 * time.Minute).Format(time.RFC3339)}},
+		// Starts in 25 minutes.
+		{Id: "25 mins from now", Start: &calendar.EventDateTime{DateTime: time.Now().Add(25 * time.Minute).Format(time.RFC3339)}},
+	}
+
+	nextEventByStartTime := NextEventByStartTime(events)
+	assert.Equal(t, nextEventByStartTime.Id, "5 mins from now")
+}
+
 func newFakeGoogleCalendarService(t *testing.T, mux http.Handler) (*calendar.Service, func()) {
 	service, err := calendar.New(&http.Client{})
 	if err != nil {


### PR DESCRIPTION
I do not like this code, but wanted to open for a discussion.

Say you have a few events:
1. A meeting 10-11am
2. A meeting 11am-11:30am
3. A meeting 11:30am-12pm

If it's currently 10:55am, the current behavior is to open up meeting `1`, since it's first. But don't you want the next meeting starting in 5 minutes?

With this branch, the code checks each meeting for its "closeness" to the present time and opens whatever *starts closest to now* (if within 5 minutes).

Is this behavior desired by others?