### PR TITLE
Handle zoom URL's without a subdomain

### DIFF
--- a/call.go
+++ b/call.go
@@ -38,7 +38,7 @@ func extractZoomCallURL(input string) (*url.URL, bool) {
 		if err != nil {
 			continue
 		}
-		if strings.HasSuffix(u.Hostname(), ".zoom.us") {
+		if strings.HasSuffix(u.Hostname(), ".zoom.us") || u.Hostname() == "zoom.us" {
 			return u, true
 		}
 	}

--- a/call_test.go
+++ b/call_test.go
@@ -13,6 +13,14 @@ func TestExtractZoomCallData(t *testing.T) {
 	}{
 		{"https://github.com", call{}},
 		{
+			"\n\n\nConference: https://zoom.us/j/9851224\n\n",
+			call{id: "9851224", originalURL: "https://zoom.us/j/9851224"},
+		},
+		{
+			"\n\n\nConference: https://usweb04.zoom.us/j/2315\n\n",
+			call{id: "2315", originalURL: "https://usweb04.zoom.us/j/2315"},
+		},
+		{
 			"\n\n\nConference: https://jithub.zoom.us/j/12345\n\n",
 			call{id: "12345", originalURL: "https://jithub.zoom.us/j/12345"},
 		},


### PR DESCRIPTION
I have seen some links without a subdomain, so this should fix handling those.